### PR TITLE
ADAPT-1737 H5P branching fullscreen issue

### DIFF
--- a/vendor/h5p/js/h5p.js
+++ b/vendor/h5p/js/h5p.js
@@ -673,7 +673,7 @@ H5P.fullScreen = function ($element, instance, exitCallback, body, forceSemiFull
 
     before('h5p-fullscreen');
     var first, eventName = (H5P.fullScreenBrowserPrefix === 'ms' ? 'MSFullscreenChange' : H5P.fullScreenBrowserPrefix + 'fullscreenchange');
-    document.addEventListener(eventName, function () {
+    document.addEventListener(eventName, function fullscreenCallback() {
       if (first === undefined) {
         // We are entering fullscreen mode
         first = false;
@@ -683,7 +683,7 @@ H5P.fullScreen = function ($element, instance, exitCallback, body, forceSemiFull
 
       // We are exiting fullscreen
       done('h5p-fullscreen');
-      document.removeEventListener(eventName, arguments.callee, false);
+      document.removeEventListener(eventName, fullscreenCallback, false);
     });
 
     if (H5P.fullScreenBrowserPrefix === '') {


### PR DESCRIPTION
When embedding h5p and using the fullscreen enter/exit feature in h5p branching, It's produce the following error:
TypeError: 'caller', 'callee', and 'arguments' properties may not be accessed on strict mode functions or the arguments objects for calls to them
at HTMLDocument.

I github bug fixes in h5p-library They added solutions for this issue in h5p-php-library.  So I have impelement this fix in our h5p-standalone. Link is added below.
https://github.com/tunapanda/h5p-standalone/issues/106
https://github.com/h5p/h5p-php-library/pull/113/commits/2582c50783709c6c6c57e80bb8f38191108ab420